### PR TITLE
Feat/profile update

### DIFF
--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -99,3 +99,23 @@ class SignupSerializer(serializers.ModelSerializer):
             marketing_agree=validated_data.get("marketing_agree", False),
         )
         return user
+
+
+# 회원 프로필 수정 직렬화
+class ProfileUpdateSerializer(serializers.ModelSerializer):
+    """회원 프로필 수정 직렬화"""
+
+    email = serializers.EmailField(read_only=True)  # 이메일 필드 추가 (읽기 전용)
+
+    class Meta:
+        model = User
+        fields = [
+            "email",
+            "name",
+            "birth_date",
+            "interests",
+            "location",
+            "current_status",
+            "education_level",
+            "marketing_agree",
+        ]

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
-from .views import LogoutView, SignupView
+from .views import LogoutView, ProfileView, SignupView
 
 app_name = "accounts"
 
@@ -18,4 +18,5 @@ urlpatterns = [
         name="token_refresh",
     ),
     path("logout/", LogoutView.as_view(), name="logout"),
+    path("profile/", ProfileView.as_view(), name="profile"),
 ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -4,7 +4,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework_simplejwt.tokens import RefreshToken
 
-from .serializers import SignupSerializer, UserSerializer
+from .serializers import ProfileUpdateSerializer, SignupSerializer, UserSerializer
 
 User = get_user_model()
 
@@ -60,3 +60,14 @@ class LogoutView(APIView):
                 {"error": "유효하지 않은 토큰입니다."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
+
+
+# 회원 프로필 조회 및 수정 API (GET, PUT /api/v1/accounts/profile/)
+class ProfileView(generics.RetrieveUpdateAPIView):
+    """회원 프로필 조회 및 수정 API"""
+
+    serializer_class = ProfileUpdateSerializer
+
+    def get_object(self):
+        """현재 로그인한 사용자 반환"""
+        return self.request.user


### PR DESCRIPTION
## 관련 이슈
- 해당없음

## 작업 내용
- `ProfileUpdateSerializer` 추가 (회원 프로필 수정 전용 직렬화)
- 프로필 조회 시 `email` 필드 포함 (읽기 전용)
- 회원 프로필 조회 및 수정 API 구현
- `api/v1/accounts/profile/` 엔드포인트 추가

## 테스트 체크리스트
- [x] 로컬 테스트 완료
- [x] Postman으로 API 정상 동작 확인
- [x] 코드 컨벤션 준수
- [x] 불필요한 코드 제거

## 스크린샷

## 참고 사항
- `GET /api/v1/accounts/profile/` : 로그인한 사용자의 프로필 정보 조회
- `PATCH /api/v1/accounts/profile/` : 회원 프로필 수정 (`email` 수정 불가)
- 프론트엔드에서 프로필 수정 요청 시 `email` 필드는 `disabled` 처리 필요