### PR TITLE
Feature/delete account

### DIFF
--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -3,6 +3,7 @@ from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
 from .views import (
     CurrentStatusListView,
+    DeleteAccountView,
     EducationLevelListView,
     InterestListView,
     LogoutView,
@@ -37,4 +38,5 @@ urlpatterns = [
         EducationLevelListView.as_view(),
         name="education_level_list",
     ),
+    path("delete/", DeleteAccountView.as_view(), name="delete_account"),
 ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -116,3 +116,23 @@ class EducationLevelListView(generics.ListAPIView):
     queryset = EducationLevel.objects.all()
     serializer_class = EducationLevelSerializer
     permission_classes = [permissions.AllowAny]
+
+
+# 회원 탈퇴 (DELETE /api/v1/accounts/delete/)
+class DeleteAccountView(APIView):
+
+    def delete(self, request):
+        """현재 로그인한 사용자의 계정을 삭제"""
+        user = request.user  # 현재 로그인한 사용자 가져오기
+
+        try:
+            user.delete()  # User 모델의 delete 메서드 호출 (소셜 계정도 함께 삭제됨)
+            return Response(
+                {"message": "회원 탈퇴가 완료되었습니다."},
+                status=status.HTTP_204_NO_CONTENT,
+            )
+        except Exception as e:
+            return Response(
+                {"error": f"회원 탈퇴 중 오류가 발생했습니다: {str(e)}"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )


### PR DESCRIPTION
## 관련 이슈
- 해당없음

## 작업 내용
- 회원 탈퇴 API (`DELETE /api/v1/accounts/delete/`) 추가
 - `DeleteAccountView` 클래스 생성 (APIView 기반)
 - `request.user.delete()`를 호출하여 사용자 및 소셜 계정 삭제
 - `IsAuthenticated` 권한을 적용하여 로그인한 사용자만 탈퇴 가능하도록 설정
 - 탈퇴 성공 시 `204 No Content` 응답 반환
- 예외 발생 시 `500 Internal Server Error` 응답 반환
- `urls.py`에 회원 탈퇴 엔드포인트 추가

## 테스트 체크리스트
- [x] 로컬 테스트 완료
- [x] 코드 컨벤션 준수
- [x] 불필요한 코드 제거

## 스크린샷
(해당 사항 없음)

## 참고 사항
- 회원 탈퇴 시 **소셜 계정도 함께 삭제**되도록 `User` 모델의 `delete()` 메서드를 활용
- `DELETE` 요청이므로 **Body 없이 요청 가능**, `Authorization` 헤더에 JWT 액세스 토큰 필요
