### PR TITLE
Fix/profile update

### DIFF
--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -39,15 +39,30 @@ class SubRegionSerializer(serializers.ModelSerializer):
 
 # 사용자 기본 정보 직렬화
 class UserSerializer(serializers.ModelSerializer):
-    """기본 사용자 정보 직렬화"""
+    """회원 프로필 조회 및 수정 직렬화"""
 
+    email = serializers.EmailField(read_only=True)  # 이메일 필드 (읽기 전용)
     is_social = serializers.SerializerMethodField()  # 소셜 로그인 여부 확인
-    interests = InterestSerializer(
-        many=True, read_only=True
-    )  # 다대다 관계 (사용자 관심 분야)
-    education_level = EducationLevelSerializer(read_only=True)  # FK
-    current_status = CurrentStatusSerializer(read_only=True)  # FK
-    location = SubRegionSerializer(read_only=True)  # FK (지역 정보)
+
+    # 프로필 조회 시 객체 반환
+    interests = InterestSerializer(many=True, read_only=True)  # ManyToMany (읽기 전용)
+    education_level = EducationLevelSerializer(read_only=True)  # ForeignKey (읽기 전용)
+    current_status = CurrentStatusSerializer(read_only=True)  # ForeignKey (읽기 전용)
+    location = SubRegionSerializer(read_only=True)  # ForeignKey (읽기 전용)
+
+    # 프로필 수정 시 ID 값만 받기
+    interests_ids = serializers.PrimaryKeyRelatedField(
+        queryset=Interest.objects.all(), many=True, write_only=True
+    )
+    education_level_id = serializers.PrimaryKeyRelatedField(
+        queryset=EducationLevel.objects.all(), write_only=True, allow_null=True
+    )
+    current_status_id = serializers.PrimaryKeyRelatedField(
+        queryset=CurrentStatus.objects.all(), write_only=True, allow_null=True
+    )
+    location_id = serializers.PrimaryKeyRelatedField(
+        queryset=SubRegion.objects.all(), write_only=True, allow_null=True
+    )
 
     class Meta:
         model = User
@@ -56,10 +71,14 @@ class UserSerializer(serializers.ModelSerializer):
             "email",
             "name",
             "birth_date",
-            "interests",
-            "location",
-            "current_status",
-            "education_level",
+            "interests",  # GET 요청 시 객체 반환
+            "interests_ids",  # PUT 요청 시 ID 값으로 업데이트
+            "location",  # GET 요청 시 객체 반환
+            "location_id",  # PUT 요청 시 ID 값으로 업데이트
+            "current_status",  # GET 요청 시 객체 반환
+            "current_status_id",  # PUT 요청 시 ID 값으로 업데이트
+            "education_level",  # GET 요청 시 객체 반환
+            "education_level_id",  # PUT 요청 시 ID 값으로 업데이트
             "is_social",  # 소셜 로그인 여부
             "terms_agree",
             "marketing_agree",
@@ -69,6 +88,29 @@ class UserSerializer(serializers.ModelSerializer):
     def get_is_social(self, obj):
         """소셜 로그인 여부 확인"""
         return SocialAccount.objects.filter(user=obj).exists()
+
+    def update(self, instance, validated_data):
+        """프로필 업데이트 로직"""
+
+        # 관심 분야 업데이트 (ManyToMany 관계)
+        if "interests_ids" in validated_data:
+            instance.interests.set(validated_data.pop("interests_ids"))
+
+        # ForeignKey 필드 업데이트
+        instance.education_level = validated_data.pop(
+            "education_level_id", instance.education_level
+        )
+        instance.current_status = validated_data.pop(
+            "current_status_id", instance.current_status
+        )
+        instance.location = validated_data.pop("location_id", instance.location)
+
+        # 나머지 필드 업데이트
+        for attr, value in validated_data.items():
+            setattr(instance, attr, value)
+
+        instance.save()
+        return instance
 
 
 # 회원가입 직렬화 (회원가입에 필요한 필드만 포함)
@@ -99,23 +141,3 @@ class SignupSerializer(serializers.ModelSerializer):
             marketing_agree=validated_data.get("marketing_agree", False),
         )
         return user
-
-
-# 회원 프로필 수정 직렬화
-class ProfileUpdateSerializer(serializers.ModelSerializer):
-    """회원 프로필 수정 직렬화"""
-
-    email = serializers.EmailField(read_only=True)  # 이메일 필드 추가 (읽기 전용)
-
-    class Meta:
-        model = User
-        fields = [
-            "email",
-            "name",
-            "birth_date",
-            "interests",
-            "location",
-            "current_status",
-            "education_level",
-            "marketing_agree",
-        ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -9,7 +9,6 @@ from .serializers import (
     CurrentStatusSerializer,
     EducationLevelSerializer,
     InterestSerializer,
-    ProfileUpdateSerializer,
     SignupSerializer,
     SubRegionSerializer,
     UserSerializer,
@@ -75,7 +74,7 @@ class LogoutView(APIView):
 class ProfileView(generics.RetrieveUpdateAPIView):
     """회원 프로필 조회 및 수정 API"""
 
-    serializer_class = ProfileUpdateSerializer
+    serializer_class = UserSerializer
 
     def get_object(self):
         """현재 로그인한 사용자 반환"""


### PR DESCRIPTION
## 관련 이슈
- 없음

## 작업 내용
- `UserSerializer`를 수정하여 프로필 조회 시 `interests`, `education_level`, `current_status`, `location`이 ID가 아닌 객체로 반환되도록 변경
- `ProfileView`에서 `ProfileUpdateSerializer` 대신 `UserSerializer`를 사용하여 프로필 조회 및 수정이 일관되게 동작하도록 수정
- `serializers.py`에서 `update` 메서드를 오버라이드하여 `interests`, `education_level`, `current_status`, `location`을 ID로 받을 수 있도록 개선

## 테스트 체크리스트
- [x] 로컬 테스트 완료
- [x] 코드 컨벤션 준수
- [x] 불필요한 코드 제거

## 스크린샷
해당 없음

## 참고 사항
- 기존 `ProfileUpdateSerializer`를 제거하고 `UserSerializer` 하나로 통합하여 관리할 수 있도록 개선했습니다.
- API 응답 형식이 변경되었으므로 프론트엔드에서도 수정이 필요합니다.
