### PR TITLE
🔧 Setup: pymupdf 추가 및 numpy 버전 지정

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ django-cors-headers==4.7.0
 flake8==7.1.2
 isort==6.0.1
 black==25.1.0
+numpy==1.26.4
 requests==2.32.3
 cryptography==44.0.2
 langchain==0.2.17
@@ -15,3 +16,4 @@ langchain-community==0.2.19
 langchain-core==0.2.43
 langchain-openai==0.1.25
 langchain-text-splitters==0.2.4
+pymupdf==1.25.3


### PR DESCRIPTION
## 관련 이슈


## 작업 내용
- langchain 및 관련 패키지들이 numpy < 2.0.0을 요구하는데 pip가 최신 버전(numpy 2.2.3)을 설치하면서 충돌 발생하여 numpy 버전을 1.26.4로 맞춤
- pymupdf 추가

## 테스트 체크리스트
- [x] 로컬 테스트 완료
- [x] 코드 컨벤션 준수
- [x] 불필요한 코드 제거

## 스크린샷


## 참고 사항
